### PR TITLE
fix: .NET 10 Apple compatibility for notifications

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -26,10 +26,10 @@
         <!-- Uno-compatible TargetFrameworks -->
         <WindowsTarget Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows10.0.26100</WindowsTarget>
         <StandardTargetFrameworks>net10.0</StandardTargetFrameworks>
-        <IosTargetFrameworks>net10.0-ios18.0</IosTargetFrameworks>
+        <IosTargetFrameworks>net10.0-ios26.0</IosTargetFrameworks>
         <AndroidTargetFrameworks>net10.0-android36.0</AndroidTargetFrameworks>
         <DesktopTargetFrameworks>net10.0-desktop</DesktopTargetFrameworks>
-        <AppleTargetFrameworks>$(IosTargetFrameworks);net10.0-maccatalyst18.0</AppleTargetFrameworks>
+        <AppleTargetFrameworks>$(IosTargetFrameworks);net10.0-maccatalyst26.0</AppleTargetFrameworks>
         <PlatformOnlyTargetFrameworks>$(AppleTargetFrameworks);$(AndroidTargetFrameworks)</PlatformOnlyTargetFrameworks>
         <DefaultMobileTargetFrameworks>$(StandardTargetFrameworks);$(IosTargetFrameworks);$(AndroidTargetFrameworks)</DefaultMobileTargetFrameworks>
         <DefaultTargetFrameworks>$(StandardTargetFrameworks);$(PlatformOnlyTargetFrameworks)</DefaultTargetFrameworks>
@@ -37,7 +37,7 @@
 
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <IncludeSource>True</IncludeSource>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PublishRepositoryUrl>True</PublishRepositoryUrl>

--- a/src/Shiny.Notifications/Platforms/Apple/ApplePlatformExtensions.cs
+++ b/src/Shiny.Notifications/Platforms/Apple/ApplePlatformExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Foundation;
 using Shiny.Locations;
 using UserNotifications;
 
@@ -7,6 +9,36 @@ namespace Shiny.Notifications;
 
 public static class ApplePlatformExtensions
 {
+    // .NET 10 compatibility helper - IsAppleVersionAtleast was removed
+    internal static bool IsAppleVersionAtLeast(int major, int minor = 0, int build = 0)
+        => OperatingSystem.IsIOSVersionAtLeast(major, minor, build) ||
+           OperatingSystem.IsMacCatalystVersionAtLeast(major, minor, build);
+
+    // NSDate.ToDateTime() extension was removed in .NET 10
+    internal static DateTime ToDateTime(this NSDate nsDate)
+    {
+        var reference = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        return reference.AddSeconds(nsDate.SecondsSinceReferenceDate).ToLocalTime();
+    }
+
+    // IDictionary<string,string>.ToNsDictionary() extension was removed in .NET 10
+    internal static NSDictionary ToNsDictionary(this IDictionary<string, string> dictionary)
+    {
+        if (dictionary == null || dictionary.Count == 0)
+            return new NSDictionary();
+
+        var keys = new NSString[dictionary.Count];
+        var values = new NSString[dictionary.Count];
+        var i = 0;
+        foreach (var kvp in dictionary)
+        {
+            keys[i] = new NSString(kvp.Key);
+            values[i] = new NSString(kvp.Value ?? string.Empty);
+            i++;
+        }
+        return NSDictionary.FromObjectsAndKeys(values, keys);
+    }
+
     public static AppleNotification FromNative(this UNNotificationRequest native)
     {
         var id = 0;
@@ -25,7 +57,7 @@ public static class ApplePlatformExtensions
         };
 
 
-        if (OperatingSystem.IsAppleVersionAtleast(16))
+        if (IsAppleVersionAtLeast(16))
         {
             if (native.Content?.RelevanceScore > 0)
                 shiny.RelevanceScore = native.Content!.RelevanceScore!;

--- a/src/Shiny.Notifications/Platforms/Apple/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Apple/NotificationManager.cs
@@ -7,7 +7,7 @@ using Foundation;
 using UIKit;
 using UserNotifications;
 using CoreLocation;
-using Shiny.Hosting;
+// using Shiny.Hosting; - Types moved to Shiny namespace
 using Shiny.Extensions.Stores;
 using Microsoft.Extensions.Logging;
 
@@ -170,7 +170,7 @@ public class NotificationManager : INotificationManager, IIosLifecycle.INotifica
             if (apple.Subtitle != null)
                 content.Subtitle = apple.Subtitle;
             
-            if (OperatingSystem.IsAppleVersionAtleast(16))
+            if (ApplePlatformExtensions.IsAppleVersionAtLeast(16))
             {
                 content.FilterCriteria = apple.FilterCriteria;
                 content.RelevanceScore = apple.RelevanceScore;
@@ -186,7 +186,7 @@ public class NotificationManager : INotificationManager, IIosLifecycle.INotifica
 
     protected virtual void ApplyChannel(Notification notification, Channel channel, UNMutableNotificationContent native)
     {
-        if (OperatingSystem.IsAppleVersionAtleast(15))
+        if (ApplePlatformExtensions.IsAppleVersionAtLeast(15))
         {
             native.InterruptionLevel = channel.Importance switch
             {
@@ -242,7 +242,7 @@ public class NotificationManager : INotificationManager, IIosLifecycle.INotifica
             {
                 case ChannelImportance.Critical:
                 case ChannelImportance.High:
-                    var is12 = OperatingSystem.IsAppleVersionAtleast(12);
+                    var is12 = OperatingSystem.IsIOSVersionAtLeast(12) || OperatingSystem.IsMacCatalystVersionAtLeast(12);
                     native.Sound = this.configuration.UNAuthorizationOptions.HasFlag(UNAuthorizationOptions.CriticalAlert) && is12
                         ? UNNotificationSound.DefaultCriticalSound
                         : UNNotificationSound.Default;


### PR DESCRIPTION
## Summary
- Update iOS/macCatalyst TFMs to `ios26.0`/`maccatalyst26.0` for .NET 10
- Replace removed `OperatingSystem.IsAppleVersionAtleast` with manual helper method
- Add `NSDate.ToDateTime()` and `IDictionary.ToNsDictionary()` extension methods (removed in .NET 10)
- Disable `GeneratePackageOnBuild` in Release config

## Test plan
- [ ] Build Shiny.Notifications targeting net10.0-ios26.0 and net10.0-maccatalyst26.0
- [ ] Verify local notifications work on iOS/macCatalyst

🤖 Generated with [Claude Code](https://claude.com/claude-code)